### PR TITLE
Fix Issue #29: Include los_height_rx and los_height_tx in minrcs calculation

### DIFF
--- a/openburst/pcl/minrcs.py
+++ b/openburst/pcl/minrcs.py
@@ -356,7 +356,7 @@ def calculate_min_rcs_los_single_pos(
     theta_t_bearing = geofunctions.get_azimuth_between_locs(Tx.lat, Tx.lon, tgt_y, tgt_x)
     theta_t_vert = geofunctions.get_elev_angle(tgt_z, Tx.masl + Tx.ahmagl, r_t)
 
-    if r_r + r_t < dist_delay_limit:  # checks if delay threshold is valid
+    if (r_r + r_t < dist_delay_limit) or (tgt_z < los_height_rx) or (tgt_z < los_height_tx):
         rcs = -1
         snr = -1
     else:


### PR DESCRIPTION
This PR resolves Issue #29 by adding the missing `los_height_tx` and `los_height_rx` arguments to the Line of Sight (LOS) height validation inside `calculate_min_rcs_los_single_pos` in `minrcs.py`. 

Previously, the LOS conditions did not account for the target height constraints, but this fix properly compares `tgt_z` with `los_height_rx` and `los_height_tx`.
