### PR TITLE
Fix Issue #24: Preserve res_x and res_y in GridParameters 

### DIFF
--- a/openburst/types/grid_params.py
+++ b/openburst/types/grid_params.py
@@ -25,8 +25,8 @@ class GridParameters:
         self.lat_stop = lat_stop  # from top right corner point        # 47.52
         self.lon_start = lon_start  # from bottom left corner point      # 8.3
         self.lon_stop = lon_stop  # from top right corner point        # 9
-        self.res_x = (lon_stop - lon_start) / amt_pts_x  # res_x              # meter
-        self.res_y = (lat_stop - lat_start) / amt_pts_y  # res_y              # meter
+        self.res_x = res_x  # meter
+        self.res_y = res_y  # meter
         self.res_z = res_z  # tag 0 or put very high value if you don't wan to distinguish between height levels
         self.min_x = lon_start
         self.max_x = lon_stop


### PR DESCRIPTION
This PR resolves Issue #24 where the `GridParameters` class initialization incorrectly re-calculated and overwrote `res_x` and `res_y` regardless of the values passed in by the user. 

It assigns the provided `res_x` and `res_y` directly, preventing unexpected `ZeroDivisionError` issues when users manually specify the spatial resolution parameters without altering the default `amt_pts`.
