### PR TITLE
Fix Issue #20 & #23: Document velocity directions appropriately

### DIFF
--- a/openburst/functions/geofunctions.py
+++ b/openburst/functions/geofunctions.py
@@ -311,7 +311,7 @@ def monostatic_doppler(
 ):
     """computes Doppler shift in Hz from target motion as seen at ground stationary radar
     freq given in MHz, alts given in masl.
-    returns None if tgt V == 0. tgt_V is given as m/s along the lon/lat/z axis
+    returns None if tgt V == 0. tgt_V is given as m/s along the lat/lon/z (North/East/Up) axis
     see Class Target definition
     """
 

--- a/openburst/sensorcontrol/sensorController.py
+++ b/openburst/sensorcontrol/sensorController.py
@@ -213,7 +213,7 @@ def insert_air_target_tracks(request_received):
                 all_tgts_np_arr = np.vstack([all_tgts_np_arr, tgt_np_arr])
             
     # sort array by ms_after_midnight
-    # DateTimeIndex, millisecs, converted_integer_id, lat, lon, heading[0 = north..180 = south..360 = north], speed[km / h], altitude[m], track_quality, milli_secs_after_midnight, tgt_vx [vel m/s on lon axis], tgt_vy [vel m/s on lat axis], tgt_vz [vel m/s on z axis]
+    # DateTimeIndex, millisecs, converted_integer_id, lat, lon, heading[0 = north..180 = south..360 = north], speed[km / h], altitude[m], track_quality, milli_secs_after_midnight, tgt_vx [vel m/s on lat axis (North)], tgt_vy [vel m/s on lon axis (East)], tgt_vz [vel m/s on z axis (Up)]
     all_tgts_np_arr = all_tgts_np_arr[all_tgts_np_arr[:,9].argsort()] # sort with time milli_secs_after_midnight
     
 


### PR DESCRIPTION
This PR resolves Issue #20 and Issue #23 by correcting the ambiguous docstrings describing target velocity direction inputs. 

The previous docstrings ambiguously referred to `lon/lat/z axis`, which can be unclear about whether X=lon/lat and Y=lat/lon. The descriptions have been updated in `geofunctions.py` (`monostatic_doppler`) and `sensorController.py` (`insert_air_target_tracks`) to explicitly map velocities to the North/East/Up axis representation (e.g. `tgt_vx` is along the lat axis [North], `tgt_vy` along the lon axis [East]).
