### PR TITLE
Fix Issue #17: Add earth curvature correction to get_elev_angle

### DIFF
--- a/openburst/functions/geofunctions.py
+++ b/openburst/functions/geofunctions.py
@@ -91,7 +91,9 @@ def get_elev_angle(tgt_z, antenna_z, dist_tgt_antenna):
     """
 
     try:
-        elev_angle = math.asin((tgt_z - antenna_z) / dist_tgt_antenna)
+        r_e = (4.0 / 3.0) * 6371000.0  # Effective earth radius in meters
+        h_corr = (dist_tgt_antenna ** 2) / (2.0 * r_e)  # Earth curvature drop
+        elev_angle = math.asin((tgt_z - h_corr - antenna_z) / dist_tgt_antenna)
         return elev_angle
     except ValueError as e:
         print("functions.py get_elev_angle Exception: ", e)


### PR DESCRIPTION
This PR resolves Issue #17 by adding the 4/3 earth curvature effect to the elevation angle calculation inside `get_elev_angle` in `geofunctions.py`. 

The `math.asin` calculation now accurately subtracts the earth curvature drop `h_corr` before calculating the elevation angle, correcting a previously unadjusted assumption about the target's relative altitude over longer distances.
